### PR TITLE
Update the documentation related to the database implementation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -2,7 +2,8 @@
 
 1. Download the connector from [WSO2 Connector Store](https://store.wso2.com/connector/identity-challenge-questions).
 2. Navigate to the <PRODUCT_HOME>, paste the wso2is-challenge-questions-connector-x.x.x.zip file downloaded from the WSO2 Connector Store and extract it. The extracted folder will be referred to as <CONNECTOR_HOME> in the rest of this document.
-3. If you are using MacOS/Ubuntu, navigate to <CONNECTOR_HOME> and execute the following commands.
+3. Execute the database scripts in <CONNECTOR_HOME>/dbscripts folder against identity DB.
+4. If you are using MacOS/Ubuntu, navigate to <CONNECTOR_HOME> and execute the following commands.
 
     ```
     chmod u+r+x setup.sh
@@ -15,8 +16,8 @@ I. Navigate to <CONNECTOR_HOME>/dropins and copy the jars in that location to <P
 
 II. Navigate to <CONNECTOR_HOME>/api and copy the jars in that location to <PRODUCT_HOME>/repository/deployment/server/webapps/api/WEB-INF/lib/
 
-4. Navigate back to <PRODUCT_HOME> and delete the <CONNECTOR_HOME> folder. Now you have successfully installed the connector.
-5. Add the following configs to the deployment.toml file
+5. Navigate back to <PRODUCT_HOME> and delete the <CONNECTOR_HOME> folder. Now you have successfully installed the connector.
+6. Add the following configs to the deployment.toml file
 
 ```
 [server]
@@ -26,7 +27,7 @@ hide_menu_items = []
 enable = true
 ```
 
-6. Please follow these steps based on your identity server version.
+7. Please follow these steps based on your identity server version.
    - **IS-7.1.0 onwards**
      - Open the web.xml file located in the repository/deployment/server/webapps/api/WEB-INF directory.
      - Under the **<param-value>** in **jaxrs.serviceClasses** of **<servlet-name>ServerV1ApiServlet</servlet-name>** tag, add the following class:`org.wso2.carbon.identity.rest.api.server.challenge.v1.ChallengesApi`
@@ -62,8 +63,8 @@ enable = true
        <bean class="org.wso2.carbon.identity.challenge.questions.recovery.endpoint.SecurityQuestionsApi"/>
        <bean class="org.wso2.carbon.identity.challenge.questions.recovery.endpoint.ValidateAnswerApi"/>
        ```
-7. Now restart the server and login to the console.
-8. Configure the following claims
+8. Now restart the server and login to the console.
+9. Configure the following claims
 
 I. Go to `User Attributes & Stores` and select `Attributes`. 
 
@@ -77,7 +78,7 @@ Similarly create the following claims as well.
 | challengeQuestion1 | Challenge Question1 | firstChallenge|
 | challengeQuestion2 | Challenge Question2 | secondChallenge|
 
-9. Login to the management console via https://localhost:9443/carbon/ and enable the challenge questions feature by following the steps described in the [Recover password via Challenge Questions](/docs/enable-password-reset-via-challenge-questions.md).
+10. Login to the management console via https://localhost:9443/carbon/ and enable the challenge questions feature by following the steps described in the [Recover password via Challenge Questions](/docs/enable-password-reset-via-challenge-questions.md).
 
 > **Note:**
 The challenge questions feature can only be configured from the Carbon Console. Hence, please enable the feature by following the steps described in the [Recover password via Challenge Questions](/docs/enable-password-reset-via-challenge-questions.md).


### PR DESCRIPTION
## Purpose
 - Update the documentation after the introduction of the database based challenge question implementation, with directions related to executing the relevant sql script to create the IDN_CHALLENGE_QUESTION table for challenge question storage